### PR TITLE
feat: add a counter to exihibit the shared memory model

### DIFF
--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -8,11 +8,14 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class HomepageController extends AbstractController
 {
+    private int $counter = 0;
+
     #[Route("/", name: "homepage")]
     public function index(): Response
     {
        return $this->render('homepage/index.html.twig', [
             'controller_name' => 'HomepageController',
+           'counter' => ++$this->counter,
         ]);
     }
 }

--- a/templates/homepage/index.html.twig
+++ b/templates/homepage/index.html.twig
@@ -4,6 +4,7 @@
 
 {% block body %}
 Hello {{ controller_name }}!<br/>
+Counter: {{ counter }}
 <ul>
     <li><a href="/api">API Platform's Swagger UI</a></li>
     <li><a href="/api/monsters.jsonld">API Platform: collection of monsters (GET/JSON-LD)</a></li>


### PR DESCRIPTION
To reproduce:

```
docker run \                                                              
    -e FRANKENPHP_CONFIG="worker ./public/index.php 2" \
    -v $PWD:/app \
    -p 80:80 -p 443:443/tcp -p 443:443/udp \
    dunglas/frankenphp
```

cc @SerheyDolgushev