### PR TITLE
docs: detach mode for docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker run \
     -v $PWD:/app \
     -p 80:80 -p 443:443/tcp -p 443:443/udp \
     --name FrankenPHP-demo \
-    -d \
+    --wait \
     dunglas/frankenphp
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ docker run \
     -v $PWD:/app \
     -p 80:80 -p 443:443/tcp -p 443:443/udp \
     --name FrankenPHP-demo \
+    -d \
     dunglas/frankenphp
 ```
 


### PR DESCRIPTION
It's better to run docker as detached to be able to run the next docker command to load the fixtures. 